### PR TITLE
migration to XS

### DIFF
--- a/ECDH.xs
+++ b/ECDH.xs
@@ -1,0 +1,240 @@
+#include "EXTERN.h"
+#include "perl.h"
+#include "XSUB.h"
+
+#include "ppport.h"
+
+#include <openssl/opensslconf.h>	/* for OPENSSL_NO_ECDH */
+#include <openssl/buffer.h>
+#include <openssl/crypto.h>
+#include <openssl/bio.h>
+#include <openssl/bn.h>
+#include <openssl/objects.h>
+#include <openssl/rand.h>
+#include <openssl/sha.h>
+#include <openssl/err.h>
+#include <openssl/ecdh.h>
+#include <openssl/ec.h>
+
+
+#ifdef OPENSSL_NO_ECDH
+int main(int argc, char *argv[])
+{
+    croak("No ECDH support\n");
+    return(0);
+}
+#else
+#endif
+
+
+MODULE = Crypt::ECDH		PACKAGE = Crypt::ECDH		
+
+=pod
+/*Generate a new EC Keypair by openSSL nid
+ *  
+ *	
+ *
+ */
+=cut
+SV * __new_ec_keypair( group_nid )
+	SV* group_nid 	
+CODE:
+    EC_KEY *ec_key;
+    BIO 	*out = NULL;
+    long r=0, len=0;
+    unsigned char * outkey= NULL;
+    SV *key = NULL;
+
+    //get new EC curve by ID 
+    ec_key = EC_KEY_new_by_curve_name(SvIV(group_nid));
+
+    if(!EC_KEY_generate_key(ec_key))
+    {
+        //if there was an error generating the key free the key memory
+        EC_KEY_free(ec_key);
+	croak("EC key generation failed");
+    }
+	
+    //Set flag to use Key encoding using NID instead of an explicit EC curve 
+    EC_KEY_set_asn1_flag(ec_key,OPENSSL_EC_NAMED_CURVE);
+	
+    out = BIO_new(BIO_s_mem());
+    r = PEM_write_bio_ECPrivateKey(out, ec_key, NULL, NULL, 0, NULL, NULL);
+    BIO_flush(out);
+    len = BIO_get_mem_data(out, NULL);
+
+    outkey = (unsigned char * )malloc(len+1);
+    len = BIO_read(out, outkey,len);
+    outkey[len]='\0';
+
+    key = newSVpvn(outkey ,len);
+
+    /* Clean up allocated memory */
+    BIO_free(out);
+    EC_KEY_free(ec_key);
+    //free(outkey);
+
+    RETVAL = key;
+OUTPUT:
+	RETVAL
+
+=pod
+/*
+ * extract the EC pub key from an ASN.1 encoded EC keypair
+ * the key string needs to be terminated by a '\0'
+ *
+ */
+=cut
+SV * __get_ec_pub_key( in )
+SV *in
+CODE:
+    EC_KEY *ec_key;
+    BIO 	*in_eckey = NULL , *out_ec_pub_key;
+    long r=0, len=0;
+    char *outkey;
+    SV *key = NULL;
+
+    in_eckey = BIO_new(BIO_s_mem());
+    len = BIO_puts(in_eckey, SvPV(in, PL_na) );
+    //printf("\n BIP_puts written: %d ", len);
+    
+    ec_key = PEM_read_bio_ECPrivateKey(in_eckey, NULL,NULL,NULL);  
+    
+    out_ec_pub_key =BIO_new(BIO_s_mem());
+
+    r = PEM_write_bio_EC_PUBKEY(out_ec_pub_key ,ec_key);
+    len = BIO_get_mem_data(out_ec_pub_key,NULL);
+    outkey = (unsigned char* ) malloc (len+1);
+    r = BIO_read(out_ec_pub_key, outkey,len);
+    outkey[len]= '\0';
+    key = newSVpvn(outkey ,len);
+
+    /* Clean up allocated memory */
+    EC_KEY_free(ec_key);
+    BIO_free(in_eckey);
+    BIO_free(out_ec_pub_key);
+    free(outkey);
+ 
+	RETVAL = key;
+OUTPUT:
+	RETVAL
+=pod
+/*
+ * generate Session key, based on a pub key already supplied
+ * generate a new keypair and return a new private and public key 
+ *
+ */
+=cut
+
+SV * __get_ecdh_key( in_pub_ec_key, out_ec_key, out_ec_pub_key )
+SV *in_pub_ec_key
+SV *out_ec_key
+SV *out_ec_pub_key 
+CODE:
+    int keySize=200 , i=0;
+    BIO  *out = NULL , *out_pub= NULL, *in_pub=NULL ,*tmp =NULL ;
+    long r=0, len=0;
+    unsigned char outkey[keySize] ;
+    unsigned char *outbuf=NULL;
+    EC_GROUP *group = NULL;
+    EC_KEY 	*ec_pubkey = NULL , * eckey = NULL , *testkey =NULL ;
+    char *c_ec_pub_key =NULL;
+    char *c_ec_key =NULL;
+    unsigned char * sessionkey=NULL;
+    SV *key = NULL;
+
+    //read supplied public key   
+    in_pub = BIO_new(BIO_s_mem());
+    r =  BIO_puts(in_pub, SvPV(in_pub_ec_key, PL_na));
+    ec_pubkey = PEM_read_bio_EC_PUBKEY(in_pub, NULL,NULL,NULL);
+
+    if(ec_pubkey == NULL)
+    {
+	if (ec_pubkey) EC_KEY_free(ec_pubkey);
+        croak("missing or invalid public key");
+
+    }
+    
+    group = EC_KEY_get0_group(ec_pubkey);
+    if(group == NULL)
+    {
+        if (ec_pubkey) EC_KEY_free(ec_pubkey);
+        croak("failed to get key group from supplied public key");
+    }    
+
+    tmp = BIO_new(BIO_s_mem());
+    len = BIO_puts(tmp,  SvPV(out_ec_key, PL_na));
+
+     //if there is no keypair supplied via out_ec_key, create a new keypair 
+     if(len <= 0)
+     {
+	//generate new key 
+	eckey = EC_KEY_new();
+	//Set same group as used in the supplied public key
+	if(! EC_KEY_set_group(eckey, group)){
+		croak("can't set group from supplied public key");
+	}
+
+	if(!EC_KEY_generate_key(eckey))
+	{
+	    //if there was an error generating the key free the key memory
+	    if (eckey) EC_KEY_free(eckey);
+            if (ec_pubkey) EC_KEY_free(ec_pubkey);
+	    if (out) BIO_free(out);
+	    if (out_pub) BIO_free(out_pub);
+	    if (tmp) BIO_free(tmp);
+
+            croak("error key generation failed");
+	}
+
+      }else{
+	eckey = PEM_read_bio_ECPrivateKey(tmp, NULL,NULL,NULL);
+
+	    if(eckey == NULL)
+	    {
+		if (eckey) EC_KEY_free(eckey);
+                if (ec_pubkey) EC_KEY_free(ec_pubkey);
+	        if (out) BIO_free(out);
+	        if (out_pub) BIO_free(out_pub);
+	        if (tmp) BIO_free(tmp);
+
+		croak("missing private key");
+	    }
+      }
+
+     	out = BIO_new(BIO_s_mem());
+     	r = PEM_write_bio_ECPrivateKey(out, eckey, NULL, NULL, 0, NULL, NULL); 	
+     	len = BIO_get_mem_data(out, NULL );
+
+     	c_ec_key = (char *) malloc (len+1);
+     	r = BIO_read(out, c_ec_key,len);
+     	(c_ec_key)[len]= '\0';
+
+        sv_setpvn(out_ec_key,c_ec_key,len);
+
+	out_pub=BIO_new(BIO_s_mem());
+	r = PEM_write_bio_EC_PUBKEY(out_pub, eckey,NULL,NULL, 0,NULL, NULL);
+	len = BIO_get_mem_data(out_pub,NULL);
+	c_ec_pub_key = (char *) malloc (len+1);
+	r = BIO_read(out_pub, c_ec_pub_key, len);
+	(c_ec_pub_key)[len]= '\0';
+	sv_setpvn(out_ec_pub_key,c_ec_pub_key,len);
+	
+	int n = ECDH_compute_key(outkey, keySize, EC_KEY_get0_public_key(ec_pubkey), eckey, NULL );
+	printf("n = %d \n", n);
+	outkey[n]='\0';
+
+	key = newSVpvn(outkey ,n);
+	
+	//	if (outkey) free(outkey);
+		if (c_ec_key) free(c_ec_key);
+		if (c_ec_pub_key) free(c_ec_pub_key);
+		if (eckey) EC_KEY_free(eckey);
+		if (ec_pubkey) EC_KEY_free(ec_pubkey);
+		if (out) BIO_free(out);
+		if (out_pub) BIO_free(out_pub);
+		if (tmp) BIO_free(tmp);
+
+	RETVAL = key;
+OUTPUT:
+	RETVAL

--- a/ECDH.xs
+++ b/ECDH.xs
@@ -2,8 +2,6 @@
 #include "perl.h"
 #include "XSUB.h"
 
-#include "ppport.h"
-
 #include <openssl/opensslconf.h>	/* for OPENSSL_NO_ECDH */
 #include <openssl/buffer.h>
 #include <openssl/crypto.h>

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,19 @@
 use inc::Module::Install;
 
+WriteMakefile(
+    NAME              => 'Crypt::ECDH',
+    VERSION_FROM      => 'lib/Crypt/ECDH.pm', # finds $VERSION
+    PREREQ_PM         => {}, # e.g., Module::Name => 1.1
+    ($] >= 5.005 ?     ## Add these new keywords supported since 5.005
+      (ABSTRACT_FROM  => 'lib/Crypt/ECDH.pm', # retrieve abstract from module
+       AUTHOR         => 'Gideon Knocke') : ()),
+    LIBS              => ['-L/opt/local/lib -L/usr/local/lib -lcrypto'], # e.g., '-lm'
+    DEFINE            => '', # e.g., '-DHAVE_SOMETHING'
+    INC               => '-I/opt/local/include -I/usr/local/include', # e.g., '-I. -I/usr/include/other'
+	# Un-comment this if you add C files to link with later:
+    OBJECT            => '$(O_FILES)', # link all the C files too
+);
+
 name     'Crypt-ECDH';
 all_from 'lib/Crypt/ECDH.pm';
 #license  'perl';

--- a/lib/Crypt/ECDH.pm
+++ b/lib/Crypt/ECDH.pm
@@ -12,7 +12,7 @@ use base qw( Exporter );
 # names by default without a very good reason. Use EXPORT_OK instead.
 # Do not simply export all your public functions/methods/constants.
 
-# This allows declaration	use Crypt::ECDH ':all';
+# This allows declaration use Crypt::ECDH ':all';
 # If you do not need this, moving things directly into @EXPORT or @EXPORT_OK
 # will save memory.
 our %EXPORT_TAGS = ( 'all' => [ qw( new_ec_keypair get_ec_pub_key get_ecdh_key
@@ -21,23 +21,15 @@ our %EXPORT_TAGS = ( 'all' => [ qw( new_ec_keypair get_ec_pub_key get_ecdh_key
 
 our @EXPORT_OK = ( @{ $EXPORT_TAGS{'all'} } );
 our @EXPORT = qw(
-	
+  
 );
 
 our $VERSION = '0.11';
 
-use Inline C => 'DATA',
-   # VERSION => '0.10',
-    NAME => 'Crypt::ECDH';
+require XSLoader;
+XSLoader::load('Crypt::ECDH', $VERSION);
 
-use Inline C => Config => (
-    INC =>  '-I/opt/local/include -I/usr/local/include',
-    LIBS => '-L/opt/local/lib -L/usr/local/lib -lcrypto',
-    ENABLE => 'UNTAINT',
-    DIRECTORY => '/usr/local/lib/perl_inline',
-    #CLEAN_AFTER_BUILD => 0,
-);
-Inline->init;
+# Preloaded methods go here.
 
 sub new_ec_keypair{
   my $group_nid = shift;
@@ -50,7 +42,7 @@ sub new_ec_keypair{
   if( $group_nid !~ /[0-9]+/ ){
     croak("parameter EC NID is not numeric");
   }
-	
+  
   eval { $key = Crypt::ECDH::__new_ec_keypair($group_nid); };
 
   if ( $@ ne "" )
@@ -88,7 +80,7 @@ sub get_ecdh_key {
 
   if( (!defined $out_ec_key) ){
      $out_ec_key = "";
-  }	
+  } 
   
 
   eval { $ecdhkey = Crypt::ECDH::__get_ecdh_key($in_pub_ec_key,$out_ec_key,$out_ec_pub_key);};
@@ -101,244 +93,9 @@ sub get_ecdh_key {
   return { 'ECDHKey' => $ecdhkey ,
            'PEMECKey' => $out_ec_key , 
            'PEMECPubKey' => $out_ec_pub_key };
-
 }
-
-
-
 
 1;
-
-__DATA__
-
-=pod
-
-=cut
-
-__C__
-
-#include <openssl/opensslconf.h>	/* for OPENSSL_NO_ECDH */
-#include <openssl/buffer.h>
-#include <openssl/crypto.h>
-#include <openssl/bio.h>
-#include <openssl/bn.h>
-#include <openssl/objects.h>
-#include <openssl/rand.h>
-#include <openssl/sha.h>
-#include <openssl/err.h>
-#include <openssl/ecdh.h>
-#include <openssl/ec.h>
-
-
-#ifdef OPENSSL_NO_ECDH
-int main(int argc, char *argv[])
-{
-    croak("No ECDH support\n");
-    return(0);
-}
-#else
-#endif
-
-
-/*Generate a new EC Keypair by openSSL nid
- *  
- *	
- *
- */
-SV * __new_ec_keypair(SV* group_nid ){
-
-    EC_KEY *ec_key;
-    BIO 	*out = NULL;
-    long r=0, len=0;
-    unsigned char * outkey= NULL;
-    SV *key = NULL;
-
-    //get new EC curve by ID 
-    ec_key = EC_KEY_new_by_curve_name(SvIV(group_nid));
-
-    if(!EC_KEY_generate_key(ec_key))
-    {
-        //if there was an error generating the key free the key memory
-        EC_KEY_free(ec_key);
-	croak("EC key generation failed");
-    }
-	
-    //Set flag to use Key encoding using NID instead of an explicit EC curve 
-    EC_KEY_set_asn1_flag(ec_key,OPENSSL_EC_NAMED_CURVE);
-	
-    out = BIO_new(BIO_s_mem());
-    r = PEM_write_bio_ECPrivateKey(out, ec_key, NULL, NULL, 0, NULL, NULL);
-    BIO_flush(out);
-    len = BIO_get_mem_data(out, NULL);
-
-    outkey = (unsigned char * )malloc(len+1);
-    len = BIO_read(out, outkey,len);
-    outkey[len]='\0';
-
-    key = newSVpvn(outkey ,len);
-
-    /* Clean up allocated memory */
-    BIO_free(out);
-    EC_KEY_free(ec_key);
-    //free(outkey);
-
-    return key;
-}
-
-
-/*
- * extract the EC pub key from an ASN.1 encoded EC keypair
- * the key string needs to be terminated by a '\0'
- *
- */
-SV * __get_ec_pub_key( SV *in ){
-
-    EC_KEY *ec_key;
-    BIO 	*in_eckey = NULL , *out_ec_pub_key;
-    long r=0, len=0;
-    char *outkey;
-    SV *key = NULL;
-
-    in_eckey = BIO_new(BIO_s_mem());
-    len = BIO_puts(in_eckey, SvPV(in, PL_na) );
-    //printf("\n BIP_puts written: %d ", len);
-    
-    ec_key = PEM_read_bio_ECPrivateKey(in_eckey, NULL,NULL,NULL);  
-    
-    out_ec_pub_key =BIO_new(BIO_s_mem());
-
-    r = PEM_write_bio_EC_PUBKEY(out_ec_pub_key ,ec_key);
-    len = BIO_get_mem_data(out_ec_pub_key,NULL);
-    outkey = (unsigned char* ) malloc (len+1);
-    r = BIO_read(out_ec_pub_key, outkey,len);
-    outkey[len]= '\0';
-    key = newSVpvn(outkey ,len);
-
-    /* Clean up allocated memory */
-    EC_KEY_free(ec_key);
-    BIO_free(in_eckey);
-    BIO_free(out_ec_pub_key);
-    free(outkey);
- 
-    return key;
-
-}
-
-/*
- * generate Session key, based on a pub key already supplied
- * generate a new keypair and return a new private and public key 
- *
- */
-
-SV * __get_ecdh_key(SV *in_pub_ec_key,  SV *out_ec_key ,SV *out_ec_pub_key ){
-
-    int keySize=200 , i=0;
-    BIO  *out = NULL , *out_pub= NULL, *in_pub=NULL ,*tmp =NULL ;
-    long r=0, len=0;
-    unsigned char outkey[keySize] ;
-    unsigned char *outbuf=NULL;
-    EC_GROUP *group = NULL;
-    EC_KEY 	*ec_pubkey = NULL , * eckey = NULL , *testkey =NULL ;
-    char *c_ec_pub_key =NULL;
-    char *c_ec_key =NULL;
-    unsigned char * sessionkey=NULL;
-    SV *key = NULL;
-
-    //read supplied public key   
-    in_pub = BIO_new(BIO_s_mem());
-    r =  BIO_puts(in_pub, SvPV(in_pub_ec_key, PL_na));
-    ec_pubkey = PEM_read_bio_EC_PUBKEY(in_pub, NULL,NULL,NULL);
-
-    if(ec_pubkey == NULL)
-    {
-	if (ec_pubkey) EC_KEY_free(ec_pubkey);
-        croak("missing or invalid public key");
-
-    }
-    
-    group = EC_KEY_get0_group(ec_pubkey);
-    if(group == NULL)
-    {
-        if (ec_pubkey) EC_KEY_free(ec_pubkey);
-        croak("failed to get key group from supplied public key");
-    }    
-
-    tmp = BIO_new(BIO_s_mem());
-    len = BIO_puts(tmp,  SvPV(out_ec_key, PL_na));
-
-     //if there is no keypair supplied via out_ec_key, create a new keypair 
-     if(len <= 0)
-     {
-	//generate new key 
-	eckey = EC_KEY_new();
-	//Set same group as used in the supplied public key
-	if(! EC_KEY_set_group(eckey, group)){
-		croak("can't set group from supplied public key");
-	}
-
-	if(!EC_KEY_generate_key(eckey))
-	{
-	    //if there was an error generating the key free the key memory
-	    if (eckey) EC_KEY_free(eckey);
-            if (ec_pubkey) EC_KEY_free(ec_pubkey);
-	    if (out) BIO_free(out);
-	    if (out_pub) BIO_free(out_pub);
-	    if (tmp) BIO_free(tmp);
-
-            croak("error key generation failed");
-	}
-
-      }else{
-	eckey = PEM_read_bio_ECPrivateKey(tmp, NULL,NULL,NULL);
-
-	    if(eckey == NULL)
-	    {
-		if (eckey) EC_KEY_free(eckey);
-                if (ec_pubkey) EC_KEY_free(ec_pubkey);
-	        if (out) BIO_free(out);
-	        if (out_pub) BIO_free(out_pub);
-	        if (tmp) BIO_free(tmp);
-
-		croak("missing private key");
-	    }
-      }
-
-     	out = BIO_new(BIO_s_mem());
-     	r = PEM_write_bio_ECPrivateKey(out, eckey, NULL, NULL, 0, NULL, NULL); 	
-     	len = BIO_get_mem_data(out, NULL );
-
-     	c_ec_key = (char *) malloc (len+1);
-     	r = BIO_read(out, c_ec_key,len);
-     	(c_ec_key)[len]= '\0';
-
-        sv_setpvn(out_ec_key,c_ec_key,len);
-
-	out_pub=BIO_new(BIO_s_mem());
-	r = PEM_write_bio_EC_PUBKEY(out_pub, eckey,NULL,NULL, 0,NULL, NULL);
-	len = BIO_get_mem_data(out_pub,NULL);
-	c_ec_pub_key = (char *) malloc (len+1);
-	r = BIO_read(out_pub, c_ec_pub_key, len);
-	(c_ec_pub_key)[len]= '\0';
-	sv_setpvn(out_ec_pub_key,c_ec_pub_key,len);
-	
-	int n = ECDH_compute_key(outkey, keySize, EC_KEY_get0_public_key(ec_pubkey), eckey, NULL );
-	printf("n = %d \n", n);
-	outkey[n]='\0';
-
-	key = newSVpvn(outkey ,n);
-	
-	//	if (outkey) free(outkey);
-		if (c_ec_key) free(c_ec_key);
-		if (c_ec_pub_key) free(c_ec_pub_key);
-		if (eckey) EC_KEY_free(eckey);
-		if (ec_pubkey) EC_KEY_free(ec_pubkey);
-		if (out) BIO_free(out);
-		if (out_pub) BIO_free(out_pub);
-		if (tmp) BIO_free(tmp);
-
-	return key;
-}
-
 __END__
 # Below is stub documentation for your module. You'd better edit it!
 
@@ -370,129 +127,129 @@ This function requires a valid openSSL NID to create a ECKey pair. The created k
 
 Some openSSL EC NID's : 
 
-#define SN_secp112r1		"secp112r1"
-#define NID_secp112r1		704
-#define OBJ_secp112r1		OBJ_secg_ellipticCurve,6L
+#define SN_secp112r1    "secp112r1"
+#define NID_secp112r1   704
+#define OBJ_secp112r1   OBJ_secg_ellipticCurve,6L
 
-#define SN_secp112r2		"secp112r2"
-#define NID_secp112r2		705
-#define OBJ_secp112r2		OBJ_secg_ellipticCurve,7L
+#define SN_secp112r2    "secp112r2"
+#define NID_secp112r2   705
+#define OBJ_secp112r2   OBJ_secg_ellipticCurve,7L
 
-#define SN_secp128r1		"secp128r1"
-#define NID_secp128r1		706
-#define OBJ_secp128r1		OBJ_secg_ellipticCurve,28L
+#define SN_secp128r1    "secp128r1"
+#define NID_secp128r1   706
+#define OBJ_secp128r1   OBJ_secg_ellipticCurve,28L
 
-#define SN_secp128r2		"secp128r2"
-#define NID_secp128r2		707
-#define OBJ_secp128r2		OBJ_secg_ellipticCurve,29L
+#define SN_secp128r2    "secp128r2"
+#define NID_secp128r2   707
+#define OBJ_secp128r2   OBJ_secg_ellipticCurve,29L
 
-#define SN_secp160k1		"secp160k1"
-#define NID_secp160k1		708
-#define OBJ_secp160k1		OBJ_secg_ellipticCurve,9L
+#define SN_secp160k1    "secp160k1"
+#define NID_secp160k1   708
+#define OBJ_secp160k1   OBJ_secg_ellipticCurve,9L
 
-#define SN_secp160r1		"secp160r1"
-#define NID_secp160r1		709
-#define OBJ_secp160r1		OBJ_secg_ellipticCurve,8L
+#define SN_secp160r1    "secp160r1"
+#define NID_secp160r1   709
+#define OBJ_secp160r1   OBJ_secg_ellipticCurve,8L
 
-#define SN_secp160r2		"secp160r2"
-#define NID_secp160r2		710
-#define OBJ_secp160r2		OBJ_secg_ellipticCurve,30L
+#define SN_secp160r2    "secp160r2"
+#define NID_secp160r2   710
+#define OBJ_secp160r2   OBJ_secg_ellipticCurve,30L
 
-#define SN_secp192k1		"secp192k1"
-#define NID_secp192k1		711
-#define OBJ_secp192k1		OBJ_secg_ellipticCurve,31L
+#define SN_secp192k1    "secp192k1"
+#define NID_secp192k1   711
+#define OBJ_secp192k1   OBJ_secg_ellipticCurve,31L
 
-#define SN_secp224k1		"secp224k1"
-#define NID_secp224k1		712
-#define OBJ_secp224k1		OBJ_secg_ellipticCurve,32L
+#define SN_secp224k1    "secp224k1"
+#define NID_secp224k1   712
+#define OBJ_secp224k1   OBJ_secg_ellipticCurve,32L
 
-#define SN_secp224r1		"secp224r1"
-#define NID_secp224r1		713
-#define OBJ_secp224r1		OBJ_secg_ellipticCurve,33L
+#define SN_secp224r1    "secp224r1"
+#define NID_secp224r1   713
+#define OBJ_secp224r1   OBJ_secg_ellipticCurve,33L
 
-#define SN_secp256k1		"secp256k1"
-#define NID_secp256k1		714
-#define OBJ_secp256k1		OBJ_secg_ellipticCurve,10L
+#define SN_secp256k1    "secp256k1"
+#define NID_secp256k1   714
+#define OBJ_secp256k1   OBJ_secg_ellipticCurve,10L
 
-#define SN_secp384r1		"secp384r1"
-#define NID_secp384r1		715
-#define OBJ_secp384r1		OBJ_secg_ellipticCurve,34L
+#define SN_secp384r1    "secp384r1"
+#define NID_secp384r1   715
+#define OBJ_secp384r1   OBJ_secg_ellipticCurve,34L
 
-#define SN_secp521r1		"secp521r1"
-#define NID_secp521r1		716
-#define OBJ_secp521r1		OBJ_secg_ellipticCurve,35L
+#define SN_secp521r1    "secp521r1"
+#define NID_secp521r1   716
+#define OBJ_secp521r1   OBJ_secg_ellipticCurve,35L
 
-#define SN_sect113r1		"sect113r1"
-#define NID_sect113r1		717
-#define OBJ_sect113r1		OBJ_secg_ellipticCurve,4L
+#define SN_sect113r1    "sect113r1"
+#define NID_sect113r1   717
+#define OBJ_sect113r1   OBJ_secg_ellipticCurve,4L
 
-#define SN_sect113r2		"sect113r2"
-#define NID_sect113r2		718
-#define OBJ_sect113r2		OBJ_secg_ellipticCurve,5L
+#define SN_sect113r2    "sect113r2"
+#define NID_sect113r2   718
+#define OBJ_sect113r2   OBJ_secg_ellipticCurve,5L
 
-#define SN_sect131r1		"sect131r1"
-#define NID_sect131r1		719
-#define OBJ_sect131r1		OBJ_secg_ellipticCurve,22L
+#define SN_sect131r1    "sect131r1"
+#define NID_sect131r1   719
+#define OBJ_sect131r1   OBJ_secg_ellipticCurve,22L
 
-#define SN_sect131r2		"sect131r2"
-#define NID_sect131r2		720
-#define OBJ_sect131r2		OBJ_secg_ellipticCurve,23L
+#define SN_sect131r2    "sect131r2"
+#define NID_sect131r2   720
+#define OBJ_sect131r2   OBJ_secg_ellipticCurve,23L
 
-#define SN_sect163k1		"sect163k1"
-#define NID_sect163k1		721
-#define OBJ_sect163k1		OBJ_secg_ellipticCurve,1L
+#define SN_sect163k1    "sect163k1"
+#define NID_sect163k1   721
+#define OBJ_sect163k1   OBJ_secg_ellipticCurve,1L
 
-#define SN_sect163r1		"sect163r1"
-#define NID_sect163r1		722
-#define OBJ_sect163r1		OBJ_secg_ellipticCurve,2L
+#define SN_sect163r1    "sect163r1"
+#define NID_sect163r1   722
+#define OBJ_sect163r1   OBJ_secg_ellipticCurve,2L
 
-#define SN_sect163r2		"sect163r2"
-#define NID_sect163r2		723
-#define OBJ_sect163r2		OBJ_secg_ellipticCurve,15L
+#define SN_sect163r2    "sect163r2"
+#define NID_sect163r2   723
+#define OBJ_sect163r2   OBJ_secg_ellipticCurve,15L
 
-#define SN_sect193r1		"sect193r1"
-#define NID_sect193r1		724
-#define OBJ_sect193r1		OBJ_secg_ellipticCurve,24L
+#define SN_sect193r1    "sect193r1"
+#define NID_sect193r1   724
+#define OBJ_sect193r1   OBJ_secg_ellipticCurve,24L
 
-#define SN_sect193r2		"sect193r2"
-#define NID_sect193r2		725
-#define OBJ_sect193r2		OBJ_secg_ellipticCurve,25L
+#define SN_sect193r2    "sect193r2"
+#define NID_sect193r2   725
+#define OBJ_sect193r2   OBJ_secg_ellipticCurve,25L
 
-#define SN_sect233k1		"sect233k1"
-#define NID_sect233k1		726
-#define OBJ_sect233k1		OBJ_secg_ellipticCurve,26L
+#define SN_sect233k1    "sect233k1"
+#define NID_sect233k1   726
+#define OBJ_sect233k1   OBJ_secg_ellipticCurve,26L
 
-#define SN_sect233r1		"sect233r1"
-#define NID_sect233r1		727
-#define OBJ_sect233r1		OBJ_secg_ellipticCurve,27L
+#define SN_sect233r1    "sect233r1"
+#define NID_sect233r1   727
+#define OBJ_sect233r1   OBJ_secg_ellipticCurve,27L
 
-#define SN_sect239k1		"sect239k1"
-#define NID_sect239k1		728
-#define OBJ_sect239k1		OBJ_secg_ellipticCurve,3L
+#define SN_sect239k1    "sect239k1"
+#define NID_sect239k1   728
+#define OBJ_sect239k1   OBJ_secg_ellipticCurve,3L
 
-#define SN_sect283k1		"sect283k1"
-#define NID_sect283k1		729
-#define OBJ_sect283k1		OBJ_secg_ellipticCurve,16L
+#define SN_sect283k1    "sect283k1"
+#define NID_sect283k1   729
+#define OBJ_sect283k1   OBJ_secg_ellipticCurve,16L
 
-#define SN_sect283r1		"sect283r1"
-#define NID_sect283r1		730
-#define OBJ_sect283r1		OBJ_secg_ellipticCurve,17L
+#define SN_sect283r1    "sect283r1"
+#define NID_sect283r1   730
+#define OBJ_sect283r1   OBJ_secg_ellipticCurve,17L
 
-#define SN_sect409k1		"sect409k1"
-#define NID_sect409k1		731
-#define OBJ_sect409k1		OBJ_secg_ellipticCurve,36L
+#define SN_sect409k1    "sect409k1"
+#define NID_sect409k1   731
+#define OBJ_sect409k1   OBJ_secg_ellipticCurve,36L
 
-#define SN_sect409r1		"sect409r1"
-#define NID_sect409r1		732
-#define OBJ_sect409r1		OBJ_secg_ellipticCurve,37L
+#define SN_sect409r1    "sect409r1"
+#define NID_sect409r1   732
+#define OBJ_sect409r1   OBJ_secg_ellipticCurve,37L
 
-#define SN_sect571k1		"sect571k1"
-#define NID_sect571k1		733
-#define OBJ_sect571k1		OBJ_secg_ellipticCurve,38L
+#define SN_sect571k1    "sect571k1"
+#define NID_sect571k1   733
+#define OBJ_sect571k1   OBJ_secg_ellipticCurve,38L
 
-#define SN_sect571r1		"sect571r1"
-#define NID_sect571r1		734
-#define OBJ_sect571r1		OBJ_secg_ellipticCurve,39L
+#define SN_sect571r1    "sect571r1"
+#define NID_sect571r1   734
+#define OBJ_sect571r1   OBJ_secg_ellipticCurve,39L
 
 =head2 Crypt::ECDH::get_ec_pub_key(PEM_ECKey)
 


### PR DESCRIPTION
Inline-C is replaced with XS.
Makefile.PL is extended with the configuration information which was previously part of ECDH.pm.
C code is migrated to ECDH.xs whereas the perl code remains in ECDH.pm.
Syntax in ECDH.xs is adjusted.
